### PR TITLE
Seed database with bundled calendar data

### DIFF
--- a/WorkingCalendar.Server/DatabaseInitializer.cs
+++ b/WorkingCalendar.Server/DatabaseInitializer.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using WorkingCalendar.Infrastructure;
+
+namespace WorkingCalendar.Server;
+
+public class DatabaseInitializer
+{
+    private readonly CalendarDbContext _context;
+    private readonly CalendarRepositoryOptions _options;
+    private readonly IHostEnvironment _environment;
+
+    public DatabaseInitializer(
+        CalendarDbContext context,
+        IOptions<CalendarRepositoryOptions> options,
+        IHostEnvironment environment)
+    {
+        _context = context;
+        _options = options.Value;
+        _environment = environment;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _context.Database.MigrateAsync();
+
+        if (await _context.CalendarEntries.AnyAsync())
+        {
+            return;
+        }
+
+        var repository = new FileCalendarRepository(Options.Create(_options), _environment);
+        var basePath = Path.IsPathRooted(_options.BasePath)
+            ? _options.BasePath
+            : Path.Combine(_environment.ContentRootPath, _options.BasePath);
+
+        if (!Directory.Exists(basePath))
+        {
+            return;
+        }
+
+        foreach (var cultureDir in Directory.EnumerateDirectories(basePath))
+        {
+            var culture = Path.GetFileName(cultureDir);
+            foreach (var yearDir in Directory.EnumerateDirectories(cultureDir))
+            {
+                if (!int.TryParse(Path.GetFileName(yearDir), out var year))
+                {
+                    continue;
+                }
+
+                var xml = await repository.GetCalendarXmlAsync(year, culture);
+                _context.CalendarEntries.Add(new CalendarEntry
+                {
+                    Year = year,
+                    Culture = culture,
+                    Xml = xml
+                });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}
+

--- a/WorkingCalendar.Server/Program.cs
+++ b/WorkingCalendar.Server/Program.cs
@@ -26,8 +26,15 @@ builder.Services.AddSwaggerGen(options =>
     options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
 });
 builder.Services.AddHealthChecks();
+builder.Services.AddScoped<DatabaseInitializer>();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var initializer = scope.ServiceProvider.GetRequiredService<DatabaseInitializer>();
+    await initializer.InitializeAsync();
+}
 
 app.UseHealthChecks("/hc");
 


### PR DESCRIPTION
## Summary
- add DatabaseInitializer to load calendar XML files into `CalendarEntry` when empty
- invoke DatabaseInitializer at startup to seed database once

## Testing
- `/usr/bin/dotnet test WorkingCalendar.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a5af312c68832d93af2c28fe15147f