### PR TITLE
feat(helm): allow external database

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ when required.
 The Helm chart in `k8s/` ships with a post-install hook that seeds PostgreSQL
 using the SQL found in `init.pssql/sql.sql`.
 
+### Database configuration
+
+The chart can either provision its own PostgreSQL instance or connect to an
+external database. Set `db.connectionString` to use an external PostgreSQL
+server; when this value is empty and `postgres.enabled=true`, the chart
+deploys a bundled Postgres and the application reads the generated connection
+string from the `ConnectionStrings__Postgres` environment variable.
+
 ### Running the hook
 
 Install the chart and enable the initializer:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,6 +23,16 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.db.connectionString }}
+            - name: ConnectionStrings__Postgres
+              value: {{ .Values.db.connectionString | quote }}
+          {{- else if and .Values.postgres.enabled .Values.postgres.auth.enabled }}
+            - name: ConnectionStrings__Postgres
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "workingcalendar.fullname" . }}-db
+                  key: connectionString
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.targetPort }}
           resources:

--- a/helm/templates/postgres-deployment.yaml
+++ b/helm/templates/postgres-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgres.enabled }}
+{{- if and (not .Values.db.connectionString) .Values.postgres.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/postgres-service.yaml
+++ b/helm/templates/postgres-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgres.enabled }}
+{{- if and (not .Values.db.connectionString) .Values.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.postgres.auth.enabled }}
+{{- if and (not .Values.db.connectionString) .Values.postgres.enabled .Values.postgres.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +9,5 @@ type: Opaque
 data:
   username: {{ .Values.postgres.auth.username | b64enc | quote }}
   password: {{ .Values.postgres.auth.password | b64enc | quote }}
+  connectionString: {{ printf "Host=%s-postgres;Port=5432;Database=workingcalendar;Username=%s;Password=%s" (include "workingcalendar.fullname" .) .Values.postgres.auth.username .Values.postgres.auth.password | b64enc | quote }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,9 @@ ingress:
     secretName: tls-workingcalendar
     clusterIssuer: letsencrypt-production
 
+db:
+  connectionString: ""
+
 postgres:
   enabled: true
   image:


### PR DESCRIPTION
## Summary
- allow passing `db.connectionString` to use an external database
- only create postgres resources when no connection string is set
- inject `ConnectionStrings__Postgres` into server deployment

## Testing
- `dotnet test WorkingCalendar.sln`
- `helm lint helm`


------
https://chatgpt.com/codex/tasks/task_e_68a5b704db5c832d8ae1ae62563603e6