### PR TITLE
Align client and server HTTP paths for year calendar endpoint

### DIFF
--- a/WorkingCalendar.Server/WorkingCalendar.Server.http
+++ b/WorkingCalendar.Server/WorkingCalendar.Server.http
@@ -1,6 +1,6 @@
 @WorkingCalendar.Server_HostAddress = http://localhost:20080
 
-GET {{WorkingCalendar.Server_HostAddress}}/GetWorkingCalendar/
+GET {{WorkingCalendar.Server_HostAddress}}/WorkingCalendar/GetYearWorkingCalendar?year=2024&type=mssql&days=5
 Accept: application/json
 
 ###

--- a/workingcalendar.client/src/App.tsx
+++ b/workingcalendar.client/src/App.tsx
@@ -162,7 +162,7 @@ function App(this: any) {
         toggleLngLoad();
         sw ? setTheme(createTheme(getDesignTokens('dark'))) : setTheme(createTheme(getDesignTokens('light')));
         async function populateWeatherData() {
-            const response = await fetch(`WorkingCalendar/GetYearWorkingCalendar?year=${selectedYearValue}&type=${selectedDateValue}&days=${selectedDaysValue}`);
+            const response = await fetch(`/WorkingCalendar/GetYearWorkingCalendar?year=${selectedYearValue}&type=${selectedDateValue}&days=${selectedDaysValue}`);
             const data = await response.text();
             setText(data);
         };


### PR DESCRIPTION
## Summary
- point HTTP file to `/WorkingCalendar/GetYearWorkingCalendar`
- use absolute path when fetching year calendar from client

## Testing
- `npm ci`
- `npm run build`
- `dotnet test WorkingCalendar.sln`
- `curl http://localhost:20080/WorkingCalendar/GetYearWorkingCalendar?year=2024&type=mssql&days=5` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cce25780832db4a9a6558754de9a