### PR TITLE
Align dev port to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Here are some examples of why this might be useful:
 
 Thus, this table can be a useful tool for managing business processes that depend on the calendar of holidays and weekends in Russia.
 
+## Port configuration
+
+The backend listens on port **8080**. Docker and `launchSettings.json` expose the same port, and the Vite dev server proxies API calls to it. When running locally, set
+
+```bash
+ASPNETCORE_URLS=http://localhost:8080 dotnet run
+```
+
+or export `ASPNETCORE_HTTP_PORT=8080` so that both server and client target the same address.
+
 ## XML Calendar Data Source
 
 The project relies on official calendar data from the

--- a/WorkingCalendar.Server/Properties/launchSettings.json
+++ b/WorkingCalendar.Server/Properties/launchSettings.json
@@ -7,10 +7,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy",
-        "ConnectionStrings__Postgres": "Host=localhost;Database=workingcalendar;Username=workingcalendar;Password=workingcalendar"
+        "ConnectionStrings__Postgres": "Host=localhost;Database=workingcalendar;Username=workingcalendar;Password=workingcalendar",
+        "ASPNETCORE_URLS": "http://localhost:8080"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:20080"
+      "applicationUrl": "http://localhost:8080"
     },
     "https": {
       "commandName": "Project",
@@ -19,10 +20,11 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy",
-        "ConnectionStrings__Postgres": "Host=localhost;Database=workingcalendar;Username=workingcalendar;Password=workingcalendar"
+        "ConnectionStrings__Postgres": "Host=localhost;Database=workingcalendar;Username=workingcalendar;Password=workingcalendar",
+        "ASPNETCORE_URLS": "http://localhost:8080"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:20080"
+      "applicationUrl": "http://localhost:8080"
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -39,7 +41,7 @@
       "launchBrowser": true,
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
       "environmentVariables": {
-        "ASPNETCORE_HTTP_PORTS": "20080",
+        "ASPNETCORE_URLS": "http://0.0.0.0:8080",
         //"ASPNETCORE_HTTPS_PORTS": "20443",
         "ConnectionStrings__Postgres": "Host=localhost;Database=workingcalendar;Username=workingcalendar;Password=workingcalendar"
       },
@@ -52,7 +54,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:20080",
+      "applicationUrl": "http://localhost:8080",
       //"sslPort": 20443
     }
   }

--- a/workingcalendar.client/vite.config.ts
+++ b/workingcalendar.client/vite.config.ts
@@ -9,8 +9,10 @@ function resolveTarget(): string {
   if (urls && urls.length > 0) return urls[0];
 
   // 2) Раздельные переменные портов (dev)
-  if (env.ASPNETCORE_HTTPS_PORT) return `https://localhost:${env.ASPNETCORE_HTTPS_PORT}`;
-  if (env.ASPNETCORE_HTTP_PORT)  return `http://localhost:${env.ASPNETCORE_HTTP_PORT}`;
+  const httpsPort = env.ASPNETCORE_HTTPS_PORTS ?? env.ASPNETCORE_HTTPS_PORT;
+  if (httpsPort) return `https://localhost:${httpsPort.split(';')[0]}`;
+  const httpPort = env.ASPNETCORE_HTTP_PORTS ?? env.ASPNETCORE_HTTP_PORT;
+  if (httpPort)  return `http://localhost:${httpPort.split(';')[0]}`;
 
   // 3) По умолчанию — контейнерный порт API
   return 'http://localhost:8080';


### PR DESCRIPTION
## Summary
- default ASP.NET Core dev port set to 8080 in launch settings
- proxy port resolution now honors plural ASPNETCORE_*_PORTS vars
- document backend port 8080 in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing React typings and modules)*
- `DOTNET_ROLL_FORWARD=Major dotnet test WorkingCalendar.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a6cef36e40832da0c0ac32ba749a06