### PR TITLE
Handle fetch errors in App

### DIFF
--- a/workingcalendar.client/src/App.tsx
+++ b/workingcalendar.client/src/App.tsx
@@ -162,9 +162,17 @@ function App(this: any) {
         toggleLngLoad();
         sw ? setTheme(createTheme(getDesignTokens('dark'))) : setTheme(createTheme(getDesignTokens('light')));
         async function populateWeatherData() {
-            const response = await fetch(`/WorkingCalendar/GetYearWorkingCalendar?year=${selectedYearValue}&type=${selectedDateValue}&days=${selectedDaysValue}`);
-            const data = await response.text();
-            setText(data);
+            try {
+                const response = await fetch(`/WorkingCalendar/GetYearWorkingCalendar?year=${selectedYearValue}&type=${selectedDateValue}&days=${selectedDaysValue}`);
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const data = await response.text();
+                setText(data);
+            } catch (error) {
+                console.error('Ошибка загрузки данных', error);
+                setText('Ошибка загрузки данных');
+            }
         };
         populateWeatherData();
         document.title = t('title'); 


### PR DESCRIPTION
## Summary
- wrap WorkingCalendar fetch in try/catch
- log errors and show a user-friendly message when data load fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- `node -e \"...\"` *(shows error handling when server is offline)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d25bb9dc832dbf5bb74535f2665c