### PR TITLE
Add support for generating SQL across all calendar years

### DIFF
--- a/WorkingCalendar.Application/CalendarService.cs
+++ b/WorkingCalendar.Application/CalendarService.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Linq;
 using WorkingCalendar.Domain;
 
 namespace WorkingCalendar.Application;
@@ -5,7 +7,7 @@ namespace WorkingCalendar.Application;
 public interface ICalendarService
 {
     Task<string> CheckDayAsync(DateTime day, int workingDaysPerWeek);
-    Task<string> GetYearSqlAsync(int year, string type, int workingDaysPerWeek);
+    Task<string> GetYearSqlAsync(string year, string type, int workingDaysPerWeek);
 }
 
 public class CalendarService : ICalendarService
@@ -24,10 +26,27 @@ public class CalendarService : ICalendarService
         return calendar.DescribeDay(day, workingDaysPerWeek);
     }
 
-    public async Task<string> GetYearSqlAsync(int year, string type, int workingDaysPerWeek)
+    public async Task<string> GetYearSqlAsync(string year, string type, int workingDaysPerWeek)
     {
-        var xml = await _repository.GetCalendarXmlAsync(year, "ru");
+        if (year == "all")
+        {
+            var calendars = await _repository.GetAllCalendarsXmlAsync("ru");
+            var builder = new StringBuilder();
+            foreach (var entry in calendars.OrderBy(c => c.Key))
+            {
+                var yearCalendar = Calendar.FromXml(entry.Value);
+                builder.AppendLine(yearCalendar.GenerateSql(entry.Key, type, workingDaysPerWeek));
+            }
+            return builder.ToString();
+        }
+
+        if (!int.TryParse(year, out var y))
+        {
+            throw new ArgumentException("Invalid year", nameof(year));
+        }
+
+        var xml = await _repository.GetCalendarXmlAsync(y, "ru");
         var calendar = Calendar.FromXml(xml);
-        return calendar.GenerateSql(year, type, workingDaysPerWeek);
+        return calendar.GenerateSql(y, type, workingDaysPerWeek);
     }
 }

--- a/WorkingCalendar.Application/ICalendarRepository.cs
+++ b/WorkingCalendar.Application/ICalendarRepository.cs
@@ -3,4 +3,5 @@ namespace WorkingCalendar.Application;
 public interface ICalendarRepository
 {
     Task<string> GetCalendarXmlAsync(int year, string culture);
+    Task<Dictionary<int, string>> GetAllCalendarsXmlAsync(string culture);
 }

--- a/WorkingCalendar.Infrastructure/DbCalendarRepository.cs
+++ b/WorkingCalendar.Infrastructure/DbCalendarRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using WorkingCalendar.Application;
+using System.Linq;
 
 namespace WorkingCalendar.Infrastructure;
 
@@ -22,5 +23,13 @@ public class DbCalendarRepository : ICalendarRepository
             throw new InvalidOperationException($"Calendar not found for {year} {culture}");
         }
         return entry.Xml;
+    }
+
+    public async Task<Dictionary<int, string>> GetAllCalendarsXmlAsync(string culture)
+    {
+        return await _context.CalendarEntries
+            .AsNoTracking()
+            .Where(e => e.Culture == culture)
+            .ToDictionaryAsync(e => e.Year, e => e.Xml);
     }
 }

--- a/WorkingCalendar.Infrastructure/FileCalendarRepository.cs
+++ b/WorkingCalendar.Infrastructure/FileCalendarRepository.cs
@@ -37,4 +37,27 @@ public class FileCalendarRepository : ICalendarRepository
         _cache[key] = xml;
         return xml;
     }
+
+    public async Task<Dictionary<int, string>> GetAllCalendarsXmlAsync(string culture)
+    {
+        var result = new Dictionary<int, string>();
+        var basePath = Path.IsPathRooted(_options.BasePath)
+            ? _options.BasePath
+            : Path.Combine(_environment.ContentRootPath, _options.BasePath);
+        var culturePath = Path.Combine(basePath, culture);
+        if (!Directory.Exists(culturePath))
+        {
+            return result;
+        }
+        foreach (var dir in Directory.GetDirectories(culturePath))
+        {
+            var name = Path.GetFileName(dir);
+            if (int.TryParse(name, out var year))
+            {
+                var xml = await GetCalendarXmlAsync(year, culture);
+                result[year] = xml;
+            }
+        }
+        return result;
+    }
 }

--- a/WorkingCalendar.Server.Tests/CalendarServiceAllYearsTests.cs
+++ b/WorkingCalendar.Server.Tests/CalendarServiceAllYearsTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using WorkingCalendar.Application;
+using WorkingCalendar.Infrastructure;
+
+namespace WorkingCalendar.Server.Tests;
+
+public class CalendarServiceAllYearsTests
+{
+    private class TestHostEnvironment : IHostEnvironment
+    {
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public string ContentRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = Environments.Development;
+    }
+
+    [Fact]
+    public async Task GetYearSqlAsync_AllYears_FileRepository()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(tempRoot, "ru", "2023"));
+        Directory.CreateDirectory(Path.Combine(tempRoot, "ru", "2024"));
+        await File.WriteAllTextAsync(Path.Combine(tempRoot, "ru", "2023", "calendar.xml"), "<calendar/>");
+        await File.WriteAllTextAsync(Path.Combine(tempRoot, "ru", "2024", "calendar.xml"), "<calendar/>");
+
+        var env = new TestHostEnvironment { ContentRootPath = tempRoot };
+        var repoOptions = Options.Create(new CalendarRepositoryOptions { BasePath = string.Empty });
+        var repo = new FileCalendarRepository(repoOptions, env);
+        var service = new CalendarService(repo);
+
+        var sql = await service.GetYearSqlAsync("all", "postgresql", 5);
+
+        Assert.Contains("2023-01-01", sql);
+        Assert.Contains("2024-01-01", sql);
+    }
+
+    [Fact]
+    public async Task GetYearSqlAsync_AllYears_DbRepository()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<CalendarDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new CalendarDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        context.CalendarEntries.Add(new CalendarEntry { Year = 2023, Culture = "ru", Xml = "<calendar/>" });
+        context.CalendarEntries.Add(new CalendarEntry { Year = 2024, Culture = "ru", Xml = "<calendar/>" });
+        await context.SaveChangesAsync();
+
+        var repo = new DbCalendarRepository(context);
+        var service = new CalendarService(repo);
+
+        var sql = await service.GetYearSqlAsync("all", "postgresql", 5);
+
+        Assert.Contains("2023-01-01", sql);
+        Assert.Contains("2024-01-01", sql);
+    }
+}
+

--- a/WorkingCalendar.Server/Controllers/WorkingCalendarController.cs
+++ b/WorkingCalendar.Server/Controllers/WorkingCalendarController.cs
@@ -24,12 +24,12 @@ public class WorkingCalendarController : ControllerBase
     /// <summary>
     /// Generates SQL for the specified year.
     /// </summary>
-    /// <param name="year">Calendar year.</param>
+    /// <param name="year">Calendar year or "all" for all years.</param>
     /// <param name="type">Type of the generated SQL script.</param>
     /// <param name="days">Working days per week.</param>
     /// <returns>SQL script for the requested year.</returns>
     [HttpGet("GetYearWorkingCalendar")]
-    public async Task<ActionResult<string>> GetYearWorkingCalendar(int year, string type, int days)
+    public async Task<ActionResult<string>> GetYearWorkingCalendar(string year, string type, int days)
     {
         var sql = await _calendarService.GetYearSqlAsync(year, type, days);
         return Ok(sql);


### PR DESCRIPTION
## Summary
- allow WorkingCalendarController to accept string `year` and forward it to service
- add `GetAllCalendarsXmlAsync` to calendar repositories and handle "all" year in service
- include tests verifying all-year SQL generation for file and database repositories

## Testing
- `/usr/lib/dotnet/dotnet test WorkingCalendar.Server.Tests/WorkingCalendar.Server.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a700d1fbe8832d9497d1607e7f37c9