### PR TITLE
refactor: clean up kompose metadata in k8s manifests

### DIFF
--- a/k8s/workingcalendar-postgres-deployment.yaml
+++ b/k8s/workingcalendar-postgres-deployment.yaml
@@ -1,34 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-    kompose.controller.type: deployment
-    kompose.service.type: headless
-    kompose.version: 1.26.0 (40646f47)
-    kompose.volume.type: persistentVolumeClaim
   name: workingcalendar-postgres
   namespace: workingcalendar
   labels:
-    io.kompose.service: workingcalendar-postgres
     app: workingcalendar
+    app.kubernetes.io/name: workingcalendar-postgres
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: workingcalendar-postgres
+      app.kubernetes.io/name: workingcalendar-postgres
   strategy:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-        kompose.controller.type: deployment
-        kompose.service.type: headless
-        kompose.version: 1.26.0 (40646f47)
-        kompose.volume.type: persistentVolumeClaim
       labels:
-        io.kompose.service: workingcalendar-postgres
+        app: workingcalendar
+        app.kubernetes.io/name: workingcalendar-postgres
     spec:
       tolerations:
       - key: "node.kubernetes.io/unreachable"

--- a/k8s/workingcalendar-postgres-service.yaml
+++ b/k8s/workingcalendar-postgres-service.yaml
@@ -1,23 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-    kompose.controller.type: deployment
-    kompose.service.type: headless
-    kompose.version: 1.26.0 (40646f47)
-    kompose.volume.type: persistentVolumeClaim
   name: workingcalendar-postgres
   namespace: workingcalendar
   labels:
-    io.kompose.service: workingcalendar-postgres
     app: workingcalendar
+    app.kubernetes.io/name: workingcalendar-postgres
 spec:
   ports:
     - name: "5432"
       port: 5432
       targetPort: 5432
   selector:
-    io.kompose.service: workingcalendar-postgres
+    app.kubernetes.io/name: workingcalendar-postgres
   type: ClusterIP   
 

--- a/k8s/workingcalendar-server-deployment.yaml
+++ b/k8s/workingcalendar-server-deployment.yaml
@@ -1,33 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-    kompose.controller.type: deployment
-    kompose.service.expose: workingcalendar.ru
-    kompose.service.type: LoadBalancer
-    kompose.version: 1.26.0 (40646f47)
   name: workingcalendar-server
   namespace: workingcalendar
   labels:
-    io.kompose.service: workingcalendar-server
-    app.kubernetes.io/name: workingcalendar
+    app: workingcalendar
+    app.kubernetes.io/name: workingcalendar-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: workingcalendar-server
+      app.kubernetes.io/name: workingcalendar-server
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-        kompose.controller.type: deployment
-        kompose.service.expose: workingcalendar.ru
-        kompose.service.type: LoadBalancer
-        kompose.version: 1.26.0 (40646f47)
       labels:
-        io.kompose.service: workingcalendar-server
+        app: workingcalendar
+        app.kubernetes.io/name: workingcalendar-server
     spec:
       containers:
         - env:

--- a/k8s/workingcalendar-server-tcp-service.yaml
+++ b/k8s/workingcalendar-server-tcp-service.yaml
@@ -1,17 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: C:\Windows\system32\kompose.exe convert -f ..\docker-compose.yml
-    kompose.controller.type: deployment
-    kompose.service.expose: 231977.fornex.cloud
-    kompose.service.type: LoadBalancer
-    kompose.version: 1.26.0 (40646f47)
   name: workingcalendar-server
   namespace: workingcalendar
   labels:
-    io.kompose.service: workingcalendar-server
-    app.kubernetes.io/name: workingcalendar
+    app: workingcalendar
+    app.kubernetes.io/name: workingcalendar-server
 spec:
   ports:
     - name: "http"
@@ -21,7 +15,7 @@ spec:
       port: 20443
       targetPort: 20080
   selector:
-    io.kompose.service: workingcalendar-server
+    app.kubernetes.io/name: workingcalendar-server
   # externalIPs:
   # - 79.132.140.197
   type: LoadBalancer   


### PR DESCRIPTION
## Summary
- replace kompose annotations and labels with standard Kubernetes labels
- ensure selectors match new labels for server and postgres components

## Testing
- `kubectl apply --dry-run=client -f k8s/` *(fails: connection refused to localhost:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68a7121d8298832d9ed625a46d1aba0b