### PR TITLE
refactor: store postgres credentials in secret

### DIFF
--- a/k8s/postgres-secret.yaml
+++ b/k8s/postgres-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+  namespace: workingcalendar
+type: Opaque
+stringData:
+  POSTGRES_ADMIN: workingcalendar
+  POSTGRES_PASSWORD: workingcalendar

--- a/k8s/workingcalendar-postgres-deployment.yaml
+++ b/k8s/workingcalendar-postgres-deployment.yaml
@@ -29,9 +29,15 @@ spec:
       containers:
         - env:
             - name: POSTGRES_ADMIN
-              value: workingcalendar
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_ADMIN
             - name: POSTGRES_PASSWORD
-              value: workingcalendar
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
           image: postgres
           name: workingcalendar-postgres
           ports:


### PR DESCRIPTION
## Summary
- create secret manifest with Postgres credentials
- reference secret in Postgres deployment env vars

## Testing
- `/usr/bin/dotnet test WorkingCalendar.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a713ee00f0832d88cdbf4e8af38bca